### PR TITLE
f/2543 fetch valid fields

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -7,12 +7,32 @@ import { IContentSearchRequest } from '@esri/hub-search';
 import { PassThrough } from 'stream';
 import { PagingStream } from './paging-stream';
 import { getBatchedStreams } from './helpers/get-batched-streams';
+import { getHubApiUrl, hubApiRequest, RemoteServerError } from '@esri/hub-common';
 
 export class HubApiModel {
 
   async getStream (request: Request) {
     const searchRequest: IContentSearchRequest = request.res.locals.searchRequest;
     this.preprocessSearchRequest(searchRequest);
+
+    if (searchRequest.options?.fields) {
+      const validFields: string[] = await hubApiRequest('/fields');
+      const invalidFields: string[] = [];
+
+      for (const field of searchRequest.options.fields.split(',')) {
+        if (!validFields.includes(field)) {
+          invalidFields.push(field);
+        }
+      }
+
+      if (invalidFields.length) {
+        throw new RemoteServerError(
+          `The config has the following invalid entries and cannot be saved: ${invalidFields.join(', ')}`,
+          getHubApiUrl(searchRequest.options.portal),
+          400
+        );
+      }
+    }
 
     const pagingStreams: PagingStream[] = await getBatchedStreams(searchRequest);
 


### PR DESCRIPTION
[2543](https://devtopia.esri.com/dc/hub/issues/2543) - Use the newly deployed Hub V3 API  endpoint to throw an error specifying any fields that are not valid.