### PR TITLE
b/3206 add site model fetching

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -7,7 +7,7 @@ import { IContentSearchRequest } from '@esri/hub-search';
 import { PassThrough } from 'stream';
 import { PagingStream } from './paging-stream';
 import { getBatchedStreams } from './helpers/get-batched-streams';
-import { getHubApiUrl, hubApiRequest, RemoteServerError } from '@esri/hub-common';
+import { fetchSite, getHubApiUrl, getPortalApiUrl, hubApiRequest, RemoteServerError } from '@esri/hub-common';
 
 export class HubApiModel {
 
@@ -15,22 +15,22 @@ export class HubApiModel {
     const searchRequest: IContentSearchRequest = request.res.locals.searchRequest;
     this.preprocessSearchRequest(searchRequest);
 
-    if (searchRequest.options?.fields) {
+    if (searchRequest.options.fields) {
       const validFields: string[] = await hubApiRequest('/fields');
-      const invalidFields: string[] = [];
+      this.validateFields(searchRequest, validFields);
+    }
 
-      for (const field of searchRequest.options.fields.split(',')) {
-        if (!validFields.includes(field)) {
-          invalidFields.push(field);
-        }
+    // Only fetch site if site is provided and either group or orgid is undefined
+    if (
+      searchRequest.options.site && 
+      (!searchRequest.filter.group || !searchRequest.filter.orgid)
+    ) {
+      const siteCatalog = await this.getSiteCatalog(searchRequest, searchRequest.options.site);
+      if (!searchRequest.filter.group) {
+        searchRequest.filter.group = siteCatalog.groups;
       }
-
-      if (invalidFields.length) {
-        throw new RemoteServerError(
-          `The config has the following invalid entries and cannot be saved: ${invalidFields.join(', ')}`,
-          getHubApiUrl(searchRequest.options.portal),
-          400
-        );
+      if (!searchRequest.filter.orgid) {
+        searchRequest.filter.orgid = siteCatalog.orgId;
       }
     }
 
@@ -65,8 +65,47 @@ export class HubApiModel {
   getData () {}
 
   private preprocessSearchRequest(searchRequest: IContentSearchRequest): void {
+    if (!searchRequest.filter) {
+      searchRequest.filter = {};
+    }
+
+    if (!searchRequest.options) {
+      searchRequest.options = {};
+    }
+
     if (!_.has(searchRequest, 'options.portal')) {
       _.set(searchRequest, 'options.portal', 'https://www.arcgis.com');
     }
+  }
+
+  private validateFields(searchRequest: IContentSearchRequest, validFields: string[]) {
+    const invalidFields: string[] = [];
+
+    for (const field of searchRequest.options.fields.split(',')) {
+      if (!validFields.includes(field)) {
+        invalidFields.push(field);
+      }
+    }
+
+    if (invalidFields.length) {
+      throw new RemoteServerError(
+        `The config has the following invalid entries and cannot be saved: ${invalidFields.join(', ')}`,
+        getHubApiUrl(searchRequest.options.portal),
+        400
+      );
+    }
+  }
+
+  private async getSiteCatalog(searchRequest: IContentSearchRequest, site: string) {
+    const requestOptions = {
+      authentication: searchRequest.options.authentication,
+      isPortal: searchRequest.options.isPortal,
+      hubApiUrl: getHubApiUrl(searchRequest.options.portal),
+      portal: getPortalApiUrl(searchRequest.options.portal),
+    };
+
+    const siteModel = await fetchSite(site, requestOptions);
+
+    return _.get(siteModel, 'data.catalog', {});
   }
 }


### PR DESCRIPTION
[3206](https://devtopia.esri.com/dc/hub/issues/3206) - Fetches the site model such that the site catalog can be used for search in the following manner:

- If a `site` is provided and NEITHER `orgid` nor `group` filters are provided, the site model is fetched and both `group` and `orgid` are populated using the site model catalog
- If a `site` is provided, and ONLY the `group` filter is provided, the site model is fetched and the resulting catalog is used ONLY to populate the `orgid` filter. The provided `group` filter takes precedence over the groups in the site catalog.
- If a `site` is provided, and ONLY the `orgid` filter is provided, the site model is fetched and the resulting catalog is used ONLY to populate the `group` filter. The provided `orgid` filter takes precedence over the orgId in the site catalog.
- If a `site` is provided, and BOTH the `group` and `orgid` filters are provided, the site model is not fetched and the provided `group` and `orgid` filters take precedence.