### PR TITLE
f/3207 add handling for invalid scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ req.res.locals.searchRequest = {
 ```
 
 #### Notes
-A search request *must* be scoped to include at least one of the following:
+A search request **must** be scoped to include at least one of the following:
 - an "id" (`filter: { id: '<id here>' }`)
 - at least one "group" (`filter: { group: ['<group id here>'] }`)
 - an "orgid" (`filter: { orgid: '<or id here>' }`)
 - a "site" (`options: { site: '<site here>' }`)
 
-If none of the above are provided, an error will be returned. *Importantly*, if only a site is provided, it is still possible for an error to be returned if the site does not have an organization or group specified as part of its catalog.
+If none of the above are provided, an error will be returned. **Importantly**, if only a site is provided, it is still possible for an error to be returned if the site does not have an organization or group specified as part of its catalog.
 
 ### Pull the Readable Stream
 Then pass the request object to `this.model.pullStream`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ req.res.locals.searchRequest = {
 };
 ```
 
+#### Notes
+A search request *must* be scoped to include at least one of the following:
+- an "id" (`filter: { id: '<id here>' }`)
+- at least one "group" (`filter: { group: ['<group id here>'] }`)
+- an "orgid" (`filter: { orgid: '<or id here>' }`)
+- a "site" (`options: { site: '<site here>' }`)
+
+If none of the above are provided, an error will be returned. *Importantly*, if only a site is provided, it is still possible for an error to be returned if the site does not have an organization or group specified as part of its catalog.
+
 ### Pull the Readable Stream
 Then pass the request object to `this.model.pullStream`.
 ```js


### PR DESCRIPTION
[3207](https://devtopia.esri.com/dc/hub/issues/3207) - Because the provider automatically fetches all pages of results with a single request from a client, there is a major risk that requests will take a long time as thousands (and greater orders of magnitude) of results are returned to the client. That is not the intended use case for the provider. 

This PR introduces a mandatory scope for requests.

A search request **must** be scoped to include at least one of the following:
- an "id" (`filter: { id: '<id here>' }`)
- at least one "group" (`filter: { group: ['<group id here>'] }`)
- an "orgid" (`filter: { orgid: '<or id here>' }`)
- a "site" (`options: { site: '<site here>' }`)

If none of the above are provided, an error will be returned. **Importantly**, if only a site is provided, it is still possible for an error to be returned if the site does not have an organization or group specified as part of its catalog.