### PR TITLE
add support for durable download url for KML

### DIFF
--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -73,6 +73,7 @@ describe('enrichDataset function', () => {
             durableUrlCSV: 'https://arcgis.com/api/download/v1/item/123a/csv?layers=0',
             durableUrlGeoJSON: 'https://arcgis.com/api/download/v1/item/123a/geojson?layers=0',
             durableUrlShapeFile: 'https://arcgis.com/api/download/v1/item/123a/shapefile?layers=0',
+            durableUrlKML: 'https://arcgis.com/api/download/v1/item/123a/kml?layers=0',
             agoLandingPage: 'portal.arcgis.com/home/item.html?id=123a&sublayer=0',
             isLayer: true,
             license: '',

--- a/src/helpers/enrich-dataset.ts
+++ b/src/helpers/enrich-dataset.ts
@@ -31,7 +31,7 @@ export type HubSite = {
     orgBaseUrl: string,
     orgTitle: string
 };
-type FileType = 'shapefile' | 'csv' | 'geojson';
+type FileType = 'shapefile' | 'csv' | 'geojson' | 'kml';
 /**
  * Mapping from ElasticSearch geo_shape type
  * to valid GeoJSON type  
@@ -84,6 +84,7 @@ export function enrichDataset(dataset: HubDataset, hubsite: HubSite): Feature {
         additionalFields.durableUrlCSV = generateDurableDownloadUrl(dataset.id, siteUrl, 'csv');
         if (_.has(dataset, 'layer.geometryType')) {
             additionalFields.accessUrlKML = downloadLinkFor('kml');
+            additionalFields.durableUrlKML = generateDurableDownloadUrl(dataset.id, siteUrl, 'kml');
             additionalFields.accessUrlShapeFile = downloadLinkFor('zip');
             additionalFields.durableUrlShapeFile= generateDurableDownloadUrl(dataset.id, siteUrl, 'shapefile');
         }


### PR DESCRIPTION
Add durable download URL for KML as part of issue [2840](https://devtopia.esri.com/dc/hub/issues/2840#issuecomment-4161498)