### PR TITLE
Fix 0 batch when sort field is applied

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -127,6 +127,11 @@ export class HubApiModel {
   }
 
   private async _combineStreamsInSequence(sources: PagingStream[], destination: PassThrough): Promise<void> {
+    if (!sources.length) {
+      destination.end(() => { });
+      return;
+    }
+
     for (const stream of sources) {
       await new Promise((resolve, reject) => {
         stream.pipe(destination, { end: false });


### PR DESCRIPTION
This PR fixes the bug (https://devtopia.esri.com/dc/hub/issues/7627) which was caused by incorrect handling of 0 batches when streams are combined sequentially (sort fields applied).