### PR TITLE
add default where query parameter in accessURL

### DIFF
--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -77,10 +77,10 @@ describe('enrichDataset function', () => {
             agoLandingPage: 'portal.arcgis.com/home/item.html?id=123a&sublayer=0',
             isLayer: true,
             license: '',
-            accessUrlGeoJSON: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.geojson?outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
-            accessUrlCSV: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.csv?outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
-            accessUrlKML: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.kml?outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
-            accessUrlShapeFile: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.zip?outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D'
+            accessUrlGeoJSON: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.geojson?where=1=1&outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
+            accessUrlCSV: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.csv?where=1=1&outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
+            accessUrlKML: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.kml?where=1=1&outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D',
+            accessUrlShapeFile: 'https://arcgis.com/datasets/CALFIRE::DCAT_Test.zip?where=1=1&outSR=%7B%22latestWkid%22%3A3310%2C%22wkid%22%3A3310%7D'
         }
 
         const enrichedDataset = enrichDataset(hubDataset, hubsite);
@@ -233,7 +233,7 @@ describe('enrichDataset function', () => {
         };
 
         const { properties } = enrichDataset(hubDataset, hubsite);
-        expect(properties.accessUrlCSV).toBe('https://arcgis.com/datasets/nissan::skyline-gtr.csv');
+        expect(properties.accessUrlCSV).toBe('https://arcgis.com/datasets/nissan::skyline-gtr.csv?where=1=1');
 
     });
 

--- a/src/helpers/enrich-dataset.ts
+++ b/src/helpers/enrich-dataset.ts
@@ -196,14 +196,14 @@ function getAgoLandingPageUrl(datasetId: string, portalUrl: string) {
 function getDownloadLinkFn(downloadLink: string, hubDataset: any) {
     const spatialReference = _.get(hubDataset, 'server.spatialReference');
 
-    let queryStr = '';
+    let queryStr = '?where=1=1'; // default query param to get up to date file
 
     if (spatialReference) {
         const { latestWkid, wkid } = spatialReference;
 
         if (wkid) {
             const outSR = JSON.stringify({ latestWkid, wkid });
-            queryStr = `?outSR=${encodeURIComponent(outSR)}`;
+            queryStr = `${queryStr}&outSR=${encodeURIComponent(outSR)}`;
         }
     }
 


### PR DESCRIPTION
This PR add default `where=1=1` query parameter in accessURL endpoints to get latest cache files of datasets. Fix for the bug [7822](https://devtopia.esri.com/dc/hub/issues/7822) 