### PR TITLE
add durable Urls as valid enrichment fields

### DIFF
--- a/src/helpers/fields.ts
+++ b/src/helpers/fields.ts
@@ -27,5 +27,9 @@ export const ADDON_FIELDS = [
   'issuedDateTime',
   'orgTitle',
   'provenance',
-  'downloadLink'
+  'downloadLink',
+  'durableUrlCSV', 
+  'durableUrlGeoJSON', 
+  'durableUrlShapeFile', 
+  'durableUrlKML'
 ];


### PR DESCRIPTION
This PR adds download API URLs (durable download URLs) as valid enrichment fields which will allow the fields to be used in DCAT template. 

After this, durable URLs can be used in feed template in `hub-feeds-api`.

Related: https://devtopia.esri.com/dc/hub/issues/8434