### PR TITLE
B/10625 hub feeds error

### DIFF
--- a/src/helpers/enrich-dataset.test.ts
+++ b/src/helpers/enrich-dataset.test.ts
@@ -515,4 +515,34 @@ describe('enrichDataset function', () => {
         expect(geojson.properties).toBeDefined();
         expect(geojsonValidation.isFeature(geojson)).toBe(true);
     });
+
+    it('should set issuedDateTime as undefined if hub dataset created field is undefined', () => {
+        const hubDataset = {
+            id: 'foo',
+            access: 'public',
+            size: 1,
+            type: 'CSV',
+            created: undefined
+        };
+
+        const { properties } = enrichDataset(hubDataset,
+            { siteUrl: 'arcgis.com', portalUrl: 'portal.com', orgBaseUrl: 'qa.arcgis.com', orgTitle: "QA Premium Alpha Hub" });
+        expect(properties).toBeDefined()
+        expect(properties.issuedDateTime).toBeUndefined()
+    });
+
+    it('should set issuedDateTime as undefined if hub dataset created field contains invalid value', () => {
+        const hubDataset = {
+            id: 'foo',
+            access: 'public',
+            size: 1,
+            type: 'CSV',
+            created: 'invalid-string'
+        };
+
+        const { properties } = enrichDataset(hubDataset,
+            { siteUrl: 'arcgis.com', portalUrl: 'portal.com', orgBaseUrl: 'qa.arcgis.com', orgTitle: "QA Premium Alpha Hub" });
+        expect(properties).toBeDefined()
+        expect(properties.issuedDateTime).toBeUndefined()
+    });
 }) 

--- a/src/helpers/enrich-dataset.ts
+++ b/src/helpers/enrich-dataset.ts
@@ -230,7 +230,7 @@ function timestampToIsoDate (val: number): string {
 
     const date = new Date(val);
     if (date instanceof Date && !isNaN(date.valueOf())) {
-        return new Date(val).toISOString();
+        return date.toISOString();
     } 
     return undefined;
 }

--- a/src/helpers/enrich-dataset.ts
+++ b/src/helpers/enrich-dataset.ts
@@ -61,7 +61,7 @@ export function enrichDataset(dataset: HubDataset, hubsite: HubSite): Feature {
         } as UserSession) + '?f=json',
         language: _.get(dataset, 'metadata.metadata.dataIdInfo.dataLang.languageCode.@_value') || localeToLang(dataset.culture) || '',
         keyword: getDatasetKeyword(dataset),
-        issuedDateTime: _.get(dataset, 'metadata.metadata.dataIdInfo.idCitation.date.pubDate') || new Date(dataset.created).toISOString(),
+        issuedDateTime: _.get(dataset, 'metadata.metadata.dataIdInfo.idCitation.date.pubDate') || timestampToIsoDate(dataset.created),
         orgTitle,
         provenance: _.get(dataset, 'metadata.metadata.dataIdInfo.idCredit', ''),
         hubLandingPage: concatUrlAndPath(siteUrl, relative.slice(1)),
@@ -86,7 +86,7 @@ export function enrichDataset(dataset: HubDataset, hubsite: HubSite): Feature {
             additionalFields.accessUrlKML = downloadLinkFor('kml');
             additionalFields.durableUrlKML = generateDurableDownloadUrl(dataset.id, siteUrl, 'kml');
             additionalFields.accessUrlShapeFile = downloadLinkFor('zip');
-            additionalFields.durableUrlShapeFile= generateDurableDownloadUrl(dataset.id, siteUrl, 'shapefile');
+            additionalFields.durableUrlShapeFile = generateDurableDownloadUrl(dataset.id, siteUrl, 'shapefile');
         }
     }
 
@@ -223,4 +223,14 @@ function objectWithoutKeys(obj, keys): Record<string, any> {
         if (keys.indexOf(key) === -1) newObject[key] = obj[key];
         return newObject;
     }, {});
+}
+
+function timestampToIsoDate (val: number): string {
+    if (_.isNil(val)) return undefined;
+
+    const date = new Date(val);
+    if (date instanceof Date && !isNaN(date.valueOf())) {
+        return new Date(val).toISOString();
+    } 
+    return undefined;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -137,7 +137,7 @@ export class HubApiModel {
         stream.pipe(destination, { end: false });
         stream.on('end', resolve);
         stream.on('error', (err) => {
-          destination.emit('error', err)
+          destination.emit('error', err);
         });
       });
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -133,10 +133,12 @@ export class HubApiModel {
     }
 
     for (const stream of sources) {
-      await new Promise((resolve, reject) => {
+      await new Promise((resolve) => {
         stream.pipe(destination, { end: false });
         stream.on('end', resolve);
-        stream.on('error', reject);
+        stream.on('error', (err) => {
+          destination.emit('error', err)
+        });
       });
     }
     destination.emit('end');

--- a/src/paging-stream.ts
+++ b/src/paging-stream.ts
@@ -46,8 +46,7 @@ export class PagingStream extends Readable {
       if (!this._nextPageParams || this._currPage >= this._pageLimit) {
         this.push(null);
       }
-    }
-    catch (err) {
+    } catch (err) {
       this.destroy(err);
       return;
     }

--- a/src/paging-stream.ts
+++ b/src/paging-stream.ts
@@ -32,22 +32,24 @@ export class PagingStream extends Readable {
     this._pageLimit = pageLimit;
   }
 
-  async _read () {
-    let response: any;
+  async _read() {
     try {
+      let response: any;
+
       response = await this._loadPage(this._nextPageParams);
       this._currPage++;
-    } catch (err) {
+
+      this._nextPageParams = this._getNextPageParams(response);
+
+      this._streamPage(response, this.push.bind(this));
+
+      if (!this._nextPageParams || this._currPage >= this._pageLimit) {
+        this.push(null);
+      }
+    }
+    catch (err) {
       this.destroy(err);
       return;
-    }
-
-    this._nextPageParams = this._getNextPageParams(response);
-
-    this._streamPage(response, this.push.bind(this));
-
-    if (!this._nextPageParams || this._currPage >= this._pageLimit) {
-      this.push(null);
     }
   }
 }

--- a/src/paging-stream.ts
+++ b/src/paging-stream.ts
@@ -34,9 +34,7 @@ export class PagingStream extends Readable {
 
   async _read() {
     try {
-      let response: any;
-
-      response = await this._loadPage(this._nextPageParams);
+      const response = await this._loadPage(this._nextPageParams);
       this._currPage++;
 
       this._nextPageParams = this._getNextPageParams(response);


### PR DESCRIPTION
Recent hub feeds api service outage was caused by unhandled stream errors from koop provider. Specifically, when streaming dataset, the provider enriches dataset. One of the enrichment field is  `issuedDateTime` which takes in `dataset.created` field and converts it to ISO date string. It seems some dataset have `undefined` created field. So, `new Date(undefined).toISOString()` threw an error which was not handled by koop server or output plugins resulting in following error

```
unhandledRejection: Invalid time value
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)

```

Because stream errors were not handled, this would cause hub-feeds-api to go down and restart. When requesting feeds which contain datasets that have `undefined` created field property multiple times would cause  hub-feeds-api pods to go down resulting in 503 error.

This PR adds better parsing  of `created` field before converting it to ISO date string and wraps streaming and enrichment logic into `try...catch`

https://devtopia.esri.com/dc/hub/issues/10625